### PR TITLE
Travis CI

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -29,4 +29,4 @@ ratings:
   - "**.py"
   - "**.rb"
 exclude_paths:
-  - "test"
+  - "test/"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -28,4 +28,5 @@ ratings:
   - "**.php"
   - "**.py"
   - "**.rb"
-exclude_paths: []
+exclude_paths:
+  - "test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - "iojs"
+  - "6"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
+[![Build Status](https://travis-ci.org/TTUSDC/CPCEEDWebApp.svg?branch=master)](https://travis-ci.org/TTUSDC/CPCEEDWebApp)
 [![Code Climate](https://codeclimate.com/github/TTUSDC/CPCEEDWebApp/badges/gpa.svg)](https://codeclimate.com/github/TTUSDC/CPCEEDWebApp)
+
 # CPCEED Web App
 This is a time logging app for the CPCEED program at Texas Tech University.
 


### PR DESCRIPTION
Brings in [Travis CI](https://travis-ci.org) to our project.

Currently setup to only run on pull-requests but is subject to change.

Closes #59 at least for now. Will need to revisit that issue once Webpack tests are setup. [Source](https://github.com/TTUSDC/CPCEEDWebApp/issues/59#issuecomment-284186674)