### PR TITLE
Travis ci cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,8 @@ language: node_js
 node_js:
   - "iojs"
   - "6"
+cache:
+  directories:
+    - node_modules
+script:
+  - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - "iojs"
   - "6"
+  - "node"
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
Minor tweaks to the Travis config such as:
- setting up caching of `node_modules` <- this will result in **much quicker tests**
- now builds on latest Node version in addition to 6 and iojs
- explicitly defined scripts for `npm test` so future webpack testing can be easily added. 